### PR TITLE
Use environment variables in *pipeline.conf

### DIFF
--- a/mappings/factotum_chemicals.json
+++ b/mappings/factotum_chemicals.json
@@ -1,5 +1,3 @@
-// PUT factotum_chemicals/ # to load this mapping, 
-// uncomment this line and paste everything into kibana
 {
   "mappings": {
     "doc": {

--- a/pipelines/factotum_chemicals_pipeline.conf
+++ b/pipelines/factotum_chemicals_pipeline.conf
@@ -13,7 +13,7 @@ input {
         # ${SQL_DATABASE} = database name on SQL server
         # ${SQL_USER} = SQL server username
         # ${SQL_PASSWORD} = SQL server user password
-        jdbc_connection_string => "jdbc:mysql://${SQL_HOST}/${SQL_DATABASE}"
+        jdbc_connection_string => "jdbc:mysql://${SQL_HOST}:${SQL_PORT}/${SQL_DATABASE}"
         jdbc_user => "${SQL_USER}"
         jdbc_password => "${SQL_PASSWORD}"
         parameters => {}

--- a/pipelines/factotum_chemicals_pipeline.conf
+++ b/pipelines/factotum_chemicals_pipeline.conf
@@ -18,6 +18,7 @@ input {
         jdbc_password => "${SQL_PASSWORD}"
         parameters => {}
         statement => "select 
+        rc.id,
         'Chemical' as facet_model_name,
         extracted_text_id as data_document_id,
         (SELECT COUNT(*) 
@@ -39,6 +40,7 @@ output {
         # ${ELASTICSEARCH_HOST} = hostname:port of Elasticsearch instance
         hosts => ["${ELASTICSEARCH_HOST}"]
         index => "factotum_chemicals"
+        document_id => "%{id}"
     }
     # stdout {
     #     codec => rubydebug

--- a/pipelines/factotum_chemicals_pipeline.conf
+++ b/pipelines/factotum_chemicals_pipeline.conf
@@ -5,14 +5,17 @@
 
 input {
     jdbc {
-        # the jdbc_driver_library location will vary with your logstash configuration
-        jdbc_driver_library => "/usr/local/etc/logstash/mysql-connector-java-5.1.47-bin.jar"
+        # ${JDBC_DRIVER_LIBRARY} = full path to mysql-connector-java-*.jar
+        jdbc_driver_library => "${JDBC_DRIVER_LIBRARY}"
         jdbc_driver_class => "com.mysql.jdbc.Driver"
 
-        # These parameters are specific to the local_factotum development database, and will vary
-        jdbc_connection_string => "jdbc:mysql://localhost:3306/local_factotum"
-        jdbc_user => "factotum"
-        jdbc_password => "not_py_password"
+        # ${SQL_HOST} = hostname:port of SQL server
+        # ${SQL_DATABASE} = database name on SQL server
+        # ${SQL_USER} = SQL server username
+        # ${SQL_PASSWORD} = SQL server user password
+        jdbc_connection_string => "jdbc:mysql://${SQL_HOST}/${SQL_DATABASE}"
+        jdbc_user => "${SQL_USER}"
+        jdbc_password => "${SQL_PASSWORD}"
         parameters => {}
         statement => "select 
         'Chemical' as facet_model_name,
@@ -33,7 +36,8 @@ input {
 ##}
 output {
     elasticsearch {
-        hosts => ["127.0.0.1:9400"]
+        # ${ELASTICSEARCH_HOST} = hostname:port of Elasticsearch instance
+        hosts => ["${ELASTICSEARCH_HOST}"]
         index => "factotum_chemicals"
     }
     # stdout {


### PR DESCRIPTION
This extends on @mwfrost's PR #1. It uses placeholders for pipeline configuration variables. As a plus, these are transparently loaded from environment variables if they exist. This might be useful later on when we have multiple pipelines where all these variables must be changed depending on the development environment.

This is PR to merge into [`799_factotum_chemicals`](/HumanExposure/factotum_elastic/tree/799_factotum_chemicals)