### PR TITLE
1048 jdbc limits

### DIFF
--- a/pipelines/dashboard.conf
+++ b/pipelines/dashboard.conf
@@ -12,12 +12,11 @@ input {
         jdbc_connection_string => "jdbc:mysql://${SQL_HOST}:${SQL_PORT}/${SQL_DATABASE}"
         jdbc_user => "${SQL_USER}"
         jdbc_password => "${SQL_PASSWORD}"
-        
-        # Inject these parameters into the sql file
-        parameters => {}
 
-        # Run as daemon with the following cron schedule
-        # schedule = "* * * * *"
+        # Limits on query size
+        jdbc_fetch_size => 10000
+        jdbc_page_size => 10000
+        jdbc_paging_enabled => true
 
         # ${QUERIES_DIR} = path of directory containing SQL statement to execute
         statement_filepath => "${QUERIES_DIR}/dashboard.sql"

--- a/pipelines/dashboard.conf
+++ b/pipelines/dashboard.conf
@@ -21,12 +21,6 @@ input {
 
         # ${QUERIES_DIR} = path of directory containing SQL statement to execute
         statement_filepath => "${QUERIES_DIR}/dashboard.sql"
-
-        # Keep tabs on the timestamps
-        # ${LASTRUN_DIR} = path to where jdbc_logstash plugin should persist its run metadata
-        last_run_metadata_path => "${LASTRUN_DIR}/dashboard"
-        use_column_value => true
-        tracking_column => "updated_at"
     }
 }
 filter {

--- a/queries/dashboard.sql
+++ b/queries/dashboard.sql
@@ -59,20 +59,3 @@ FROM
     LEFT JOIN dashboard_dsstoxlookup dss ON rc.dsstox_id = dss.id
     LEFT JOIN dashboard_datagroup dg ON dd.data_group_id = dg.id
     LEFT JOIN dashboard_grouptype gt ON dg.group_type_id = gt.id
-WHERE
-    elp.updated_at > :sql_last_value OR
-    ehh.updated_at > :sql_last_value OR
-    efu.updated_at > :sql_last_value OR
-    ec.updated_at > :sql_last_value OR
-    dss.updated_at > :sql_last_value OR
-    et.updated_at > :sql_last_value OR
-    dd.updated_at > :sql_last_value OR
-    dg.updated_at > :sql_last_value OR
-    dg.updated_at > :sql_last_value OR
-    gt.updated_at > :sql_last_value OR
-    pd.updated_at > :sql_last_value OR
-    p.updated_at > :sql_last_value OR
-    pp.updated_at > :sql_last_value OR
-    puc.updated_at > :sql_last_value
-ORDER BY
-    updated_at;


### PR DESCRIPTION
Closes HumanExposure/factotum#1048 

Dependent on https://github.com/HumanExposure/factotum/pull/1053

Also removes Logstash timekeeping due to possible issues with multiple queries invoked via `LIMIT` and `OFFSET` done here.


This is atomic. Another PR includes this, related others, resolved merge conflicts, and cross-repository patches: https://github.com/HumanExposure/factotum_elastic/pull/9.