### PR TITLE
15: update elastic index nightly

### DIFF
--- a/logstash.conf
+++ b/logstash.conf
@@ -1,4 +1,10 @@
 input {
+    exec {
+        type => "delete_index"
+        command => 'curl -X DELETE "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/dashboard"'
+        # schedule at 1:25AM EST everyday
+        schedule => "25 1 * * * America/New_York"
+    }
     jdbc {
         # ${JDBC_DRIVER_LIBRARY} = full path to mysql-connector-java-*.jar
         jdbc_driver_library => "${JDBC_DRIVER_LIBRARY}"
@@ -18,20 +24,25 @@ input {
         # jdbc_page_size => 10000
         # jdbc_paging_enabled => true
 
+        # schedule at 1:30AM EST everyday
+        schedule => "30 1 * * * America/New_York"
+
         # ${QUERY_PATH} = path of file containing SQL statement to execute
         statement_filepath => "${QUERY_PATH}"
     }
 }
 output {
-    elasticsearch {
-        # ${ELASTICSEARCH_HOST} = hostname of Elasticsearch instance
-        # ${ELASTICSEARCH_PORT} = port of Elasticsearch instance
-        hosts => ["${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"]
-        index => "dashboard"
-        document_id => "%{datadocument_id}-%{product_id}-%{puc_id}-%{rawchem_id}"
-        # ${TEMPLATE_PATH} = path of file containing template to use
-        template => "${TEMPLATE_PATH}"
-        template_name => "dashboard_template"
-        template_overwrite => true
+    if [type] != "delete_index" {
+        elasticsearch {
+            # ${ELASTICSEARCH_HOST} = hostname of Elasticsearch instance
+            # ${ELASTICSEARCH_PORT} = port of Elasticsearch instance
+            hosts => ["${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}"]
+            index => "dashboard"
+            document_id => "%{datadocument_id}-%{product_id}-%{puc_id}-%{rawchem_id}"
+            # ${TEMPLATE_PATH} = path of file containing template to use
+            template => "${TEMPLATE_PATH}"
+            template_name => "dashboard_template"
+            template_overwrite => true
+        }
     }
 }

--- a/logstash.conf
+++ b/logstash.conf
@@ -2,8 +2,7 @@ input {
     exec {
         type => "delete_index"
         command => 'curl -X DELETE "${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/dashboard"'
-        # schedule at 1:25AM EST everyday
-        schedule => "25 1 * * * America/New_York"
+        schedule => "${DELETE_INDEX_SCHEDULE}"
     }
     jdbc {
         # ${JDBC_DRIVER_LIBRARY} = full path to mysql-connector-java-*.jar
@@ -24,8 +23,8 @@ input {
         # jdbc_page_size => 10000
         # jdbc_paging_enabled => true
 
-        # schedule at 1:30AM EST everyday
-        schedule => "30 1 * * * America/New_York"
+        # schedule
+        schedule => "${REINDEX_SCHEDULE}"
 
         # ${QUERY_PATH} = path of file containing SQL statement to execute
         statement_filepath => "${QUERY_PATH}"


### PR DESCRIPTION
1. schedule the jdbc input at configured time
2. schedule the delete_index input configured time, by exec the curl -X DELETE command. The deleted index is instant. I used a 5 minutes cap just for safeguard.
3. the scheduled times are configurable via environment variables. defaults to 1:30AM EST everyday